### PR TITLE
feat: Exclude markdown image tags from translation using placeholders

### DIFF
--- a/tests/test_nb_translate.py
+++ b/tests/test_nb_translate.py
@@ -78,6 +78,28 @@ class TestNbTranslator(TestCase):
         expected = 'aaa bbb <span translate="no">`CCC`</span> ddd <span translate="no">`EEE`</span>'
         self.assertEqual(nb_translator._exclude_code_highlight(text), expected)
 
+    def test_exclude_image_tag(self):
+        nb_translator = self.nb_translator
+        nb_translator.image_placeholders = {}
+
+        text = 'aaa bbb ![image_6.png](attachment:image_6.png) ddd'
+        expected_text = 'aaa bbb <span translate="no">__IMAGE_PLACEHOLDER_0__</span> ddd'
+        expected_placeholders = {'__IMAGE_PLACEHOLDER_0__': '![image_6.png](attachment:image_6.png)'}
+
+        processed_text = nb_translator._exclude_image_tag(text)
+
+        self.assertEqual(processed_text, expected_text)
+        self.assertEqual(nb_translator.image_placeholders, expected_placeholders)
+
+    def test_restore_image_tags(self):
+        nb_translator = self.nb_translator
+        nb_translator.image_placeholders = {'__IMAGE_PLACEHOLDER_0__': '![image_6.png](attachment:image_6.png)'}
+
+        text = 'aaa bbb __IMAGE_PLACEHOLDER_0__ ddd'
+        expected = 'aaa bbb ![image_6.png](attachment:image_6.png) ddd'
+
+        self.assertEqual(nb_translator._restore_image_tags(text), expected)
+
     def test_preprocess(self):
         nb_translator = self.nb_translator
 


### PR DESCRIPTION
This change introduces a new method to the `NbTranslator` class that prevents markdown image tags from being translated.

The `_exclude_image_tag` method uses a regular expression to find `![alt](src)` tags and replaces them with a unique placeholder. The original tag is stored in a dictionary and restored after translation. This prevents the translation service from splitting or translating the image tag, which is especially important for long, base64-encoded images.

A unit test has been added to verify the new placeholder and restoration functionality. The `image_placeholders` dictionary is now cleared at the beginning of each translation to prevent state from persisting between runs.